### PR TITLE
Compatibility with the --logfile argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Both need to set before the class is loaded and an attempt to transform is made,
 
 ## Logging
 
-Informational log messages are prefixed with `INFO SECURITY-3430 Workaround: `.
-Messages prefixed with `SEVERE SECURITY-3430 Workaround: ` indicate a failure to transform.
+Informational log messages are prefixed with `INFO io.jenkins.security.Security3430Workaround `.
+Messages prefixed with `SEVERE io.jenkins.security.Security3430Workaround ` indicate a failure to transform.
 This is not using the typical `java.util.logging.Logger` used throughout Jenkins, but rather `System.out` and `System.err` due to this code running as a Java agent that can interfere with Jenkins logging when using the --logfile argument.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Both need to set before the class is loaded and an attempt to transform is made,
 
 ## Logging
 
-Informational log messages are prefixed with `SECURITY-3430 Workaround: `.
+Informational log messages are prefixed with `INFO SECURITY-3430 Workaround: `.
 Messages prefixed with `SEVERE SECURITY-3430 Workaround: ` indicate a failure to transform.
-This is not using the typical `java.util.logging.Logger` used throughout Jenkins, but rather `System.out` and `System.err` due to this code running as a Java agent that can interfere with Jenkins logging when running via systemd.
+This is not using the typical `java.util.logging.Logger` used throughout Jenkins, but rather `System.out` and `System.err` due to this code running as a Java agent that can interfere with Jenkins logging when using the --logfile argument.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Both need to set before the class is loaded and an attempt to transform is made,
 
 ## Logging
 
-Log messages use the `io.jenkins.security.Security3430Workaround` logger.
-Messages logged on `SEVERE` indicate a failure to transform.
+Informational log messages are prefixed with `SECURITY-3430 Workaround: `.
+Messages prefixed with `SEVERE SECURITY-3430 Workaround: ` indicate a failure to transform.
+This is not using the typical `java.util.logging.Logger` used throughout Jenkins, but rather `System.out` and `System.err` due to this code running as a Java agent that can interfere with Jenkins logging when running via systemd.
 
 ## Testing
 

--- a/src/main/java/io/jenkins/security/Security3430Workaround.java
+++ b/src/main/java/io/jenkins/security/Security3430Workaround.java
@@ -34,39 +34,43 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Security3430Workaround implements ClassFileTransformer {
-    private static final Logger LOGGER = Logger.getLogger(Security3430Workaround.class.getName());
+    private static final String LOG_PREFIX = "SECURITY-3430 Workaround: ";
+    private static final String SEVERE_LOG_PREFIX = "SEVERE " + LOG_PREFIX;
+    private static void logMessage(String message) {
+        System.out.println(LOG_PREFIX + message);
+    }
+    private static void logSevereMessage(String message) {
+        System.err.println(SEVERE_LOG_PREFIX + message);
+    }
 
     @SuppressFBWarnings(value = "DM_EXIT", justification = "Failure to transform might result in unsafe state, so shutting down is intentional")
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
         if (!className.equals("hudson/remoting/RemoteClassLoader$ClassLoaderProxy")) {
-            LOGGER.log(Level.FINEST, () -> "SECURITY-3430 Workaround: Skipping transformation because class name does not match: " + className);
             return null;
         }
 
         final String systemPropertyName = Security3430Workaround.class.getName() + ".DISABLE";
         if (Boolean.getBoolean(systemPropertyName)) {
-            LOGGER.log(Level.INFO, () -> "SECURITY-3430 Workaround: Skipping transformation of " + className + " because " + systemPropertyName + " is set");
+            logMessage("Skipping transformation of " + className + " because " + systemPropertyName + " is set");
             return null;
         }
 
-        LOGGER.log(Level.INFO, () -> "SECURITY-3430 Workaround: Performing transformation of " + className);
+        logMessage("Performing transformation of " + className);
 
         final byte[] transformed = innerTransform(classfileBuffer);
         if (transformed != null) {
             return transformed;
         }
 
-        LOGGER.log(Level.SEVERE, () -> "SECURITY-3430 Workaround: Failed to find the 'fetchJar' in the class file, cannot prevent exploitation.");
+        logSevereMessage("Failed to find the 'fetchJar' in the class file, cannot prevent exploitation.");
         final String skipShutdownPropertyName = Security3430Workaround.class.getName() + ".SKIP_SHUTDOWN";
         if (Boolean.getBoolean(skipShutdownPropertyName)) {
-            LOGGER.log(Level.SEVERE, () -> "SECURITY-3430 Workaround: Skipping shutdown because " + skipShutdownPropertyName + " is set. The instance is not protected from SECURITY-3430.");
+            logSevereMessage("Skipping shutdown because " + skipShutdownPropertyName + " is set. The instance is not protected from SECURITY-3430.");
         } else {
-            LOGGER.log(Level.SEVERE, () -> "SECURITY-3430 Workaround: Shutting down.");
+            logSevereMessage("Shutting down.");
             System.exit(1);
         }
         return null;
@@ -96,26 +100,26 @@ public class Security3430Workaround implements ClassFileTransformer {
     }
 
     public static void premain(String args, Instrumentation instrumentation) {
-        LOGGER.log(Level.INFO, () -> "Setting up " + Security3430Workaround.class.getName());
+        logMessage("Setting up " + Security3430Workaround.class.getName());
         instrumentation.addTransformer(new Security3430Workaround());
     }
 
     @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "DM_EXIT"}, justification = "CLI behavior")
     public static void main(String[] args) throws IOException {
         if (args.length == 0) {
-            System.err.println("This file is a Java agent addressing SECURITY-3430/CVE-2024-43044 in older releases of Jenkins by patching bytecode.");
-            System.err.println("Usage:");
-            System.err.println("    java -javaagent:/path/to/security3430-workaround.jar -jar jenkins.war");
-            System.err.println("Additionally, this file can be used as an executable jar to patch a RemoteClassLoader$ClassLoaderProxy.class file.");
-            System.err.println("Usage:");
-            System.err.println("    java -jar /path/to/security3430-workaround.jar <source> <target>");
+            logSevereMessage("This file is a Java agent addressing SECURITY-3430/CVE-2024-43044 in older releases of Jenkins by patching bytecode.\n" +
+                "Usage:\n" +
+                "    java -javaagent:/path/to/security3430-workaround.jar -jar jenkins.war\n" +
+                "Additionally, this file can be used as an executable jar to patch a RemoteClassLoader$ClassLoaderProxy.class file.\n" +
+                "Usage:\n" +
+                "    java -jar /path/to/security3430-workaround.jar <source> <target>");
             System.exit(1);
             return;
         }
         final byte[] original = Files.readAllBytes(new File(args[0]).toPath());
         final byte[] modified = innerTransform(original);
         if (modified == null) {
-            System.err.println("Failed to transform the specified file. Is it a RemoteClassLoader$ClassLoaderProxy.class?");
+            logSevereMessage("Failed to transform the specified file. Is it a RemoteClassLoader$ClassLoaderProxy.class?");
             System.exit(1);
             return;
         }

--- a/src/main/java/io/jenkins/security/Security3430Workaround.java
+++ b/src/main/java/io/jenkins/security/Security3430Workaround.java
@@ -27,26 +27,27 @@ package io.jenkins.security;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.ProtectionDomain;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.logging.Level;
 
 public class Security3430Workaround implements ClassFileTransformer {
-    private static final String LOG_PREFIX = "SECURITY-3430 Workaround: ";
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ");
+    private static final String LOG_PREFIX = Security3430Workaround.class.getName();
+    private static final DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneOffset.UTC);
 
-    private static void logMessage(String message) {
-        System.out.println(ZonedDateTime.now().format(formatter) + " INFO " + LOG_PREFIX + message);
-    }
-
-    private static void logSevereMessage(String message) {
-        System.err.println(ZonedDateTime.now().format(formatter) + " SEVERE " + LOG_PREFIX + message);
+    private static void logMessage(Level level, String message) {
+        PrintStream stream = (level == Level.SEVERE) ? System.err : System.out;
+        stream.println(ZonedDateTime.now().format(formatter) + " " + level + " " + LOG_PREFIX + " " + message);
     }
 
     @SuppressFBWarnings(value = "DM_EXIT", justification = "Failure to transform might result in unsafe state, so shutting down is intentional")
@@ -58,23 +59,28 @@ public class Security3430Workaround implements ClassFileTransformer {
 
         final String systemPropertyName = Security3430Workaround.class.getName() + ".DISABLE";
         if (Boolean.getBoolean(systemPropertyName)) {
-            logMessage("Skipping transformation of " + className + " because " + systemPropertyName + " is set");
+            logMessage(
+                    Level.INFO,
+                    "Skipping transformation of " + className + " because " + systemPropertyName + " is set");
             return null;
         }
 
-        logMessage("Performing transformation of " + className);
+        logMessage(Level.INFO, "Performing transformation of " + className);
 
         final byte[] transformed = innerTransform(classfileBuffer);
         if (transformed != null) {
             return transformed;
         }
 
-        logSevereMessage("Failed to find the 'fetchJar' in the class file, cannot prevent exploitation.");
+        logMessage(Level.SEVERE, "Failed to find the 'fetchJar' in the class file, cannot prevent exploitation.");
         final String skipShutdownPropertyName = Security3430Workaround.class.getName() + ".SKIP_SHUTDOWN";
         if (Boolean.getBoolean(skipShutdownPropertyName)) {
-            logSevereMessage("Skipping shutdown because " + skipShutdownPropertyName + " is set. The instance is not protected from SECURITY-3430.");
+            logMessage(
+                    Level.SEVERE,
+                    "Skipping shutdown because " + skipShutdownPropertyName
+                            + " is set. The instance is not protected from SECURITY-3430.");
         } else {
-            logSevereMessage("Shutting down.");
+            logMessage(Level.SEVERE, "Shutting down.");
             System.exit(1);
         }
         return null;
@@ -104,14 +110,15 @@ public class Security3430Workaround implements ClassFileTransformer {
     }
 
     public static void premain(String args, Instrumentation instrumentation) {
-        logMessage("Setting up " + Security3430Workaround.class.getName());
+        logMessage(Level.INFO, "Setting up " + Security3430Workaround.class.getName());
         instrumentation.addTransformer(new Security3430Workaround());
     }
 
     @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "DM_EXIT"}, justification = "CLI behavior")
     public static void main(String[] args) throws IOException {
         if (args.length == 0) {
-            logSevereMessage(
+            logMessage(
+                    Level.SEVERE,
                     "This file is a Java agent addressing SECURITY-3430/CVE-2024-43044 in older releases of Jenkins by patching bytecode.\n"
                             + "Usage:\n"
                             + "    java -javaagent:/path/to/security3430-workaround.jar -jar jenkins.war\n"
@@ -124,7 +131,8 @@ public class Security3430Workaround implements ClassFileTransformer {
         final byte[] original = Files.readAllBytes(new File(args[0]).toPath());
         final byte[] modified = innerTransform(original);
         if (modified == null) {
-            logSevereMessage(
+            logMessage(
+                    Level.SEVERE,
                     "Failed to transform the specified file. Is it a RemoteClassLoader$ClassLoaderProxy.class?");
             System.exit(1);
             return;

--- a/src/main/java/io/jenkins/security/Security3430Workaround.java
+++ b/src/main/java/io/jenkins/security/Security3430Workaround.java
@@ -33,16 +33,20 @@ import java.lang.instrument.Instrumentation;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.ProtectionDomain;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 
 public class Security3430Workaround implements ClassFileTransformer {
     private static final String LOG_PREFIX = "SECURITY-3430 Workaround: ";
-    private static final String SEVERE_LOG_PREFIX = "SEVERE " + LOG_PREFIX;
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ");
+
     private static void logMessage(String message) {
-        System.out.println(LOG_PREFIX + message);
+        System.out.println(ZonedDateTime.now().format(formatter) + " INFO " + LOG_PREFIX + message);
     }
+
     private static void logSevereMessage(String message) {
-        System.err.println(SEVERE_LOG_PREFIX + message);
+        System.err.println(ZonedDateTime.now().format(formatter) + " SEVERE " + LOG_PREFIX + message);
     }
 
     @SuppressFBWarnings(value = "DM_EXIT", justification = "Failure to transform might result in unsafe state, so shutting down is intentional")
@@ -107,19 +111,21 @@ public class Security3430Workaround implements ClassFileTransformer {
     @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "DM_EXIT"}, justification = "CLI behavior")
     public static void main(String[] args) throws IOException {
         if (args.length == 0) {
-            logSevereMessage("This file is a Java agent addressing SECURITY-3430/CVE-2024-43044 in older releases of Jenkins by patching bytecode.\n" +
-                "Usage:\n" +
-                "    java -javaagent:/path/to/security3430-workaround.jar -jar jenkins.war\n" +
-                "Additionally, this file can be used as an executable jar to patch a RemoteClassLoader$ClassLoaderProxy.class file.\n" +
-                "Usage:\n" +
-                "    java -jar /path/to/security3430-workaround.jar <source> <target>");
+            logSevereMessage(
+                    "This file is a Java agent addressing SECURITY-3430/CVE-2024-43044 in older releases of Jenkins by patching bytecode.\n"
+                            + "Usage:\n"
+                            + "    java -javaagent:/path/to/security3430-workaround.jar -jar jenkins.war\n"
+                            + "Additionally, this file can be used as an executable jar to patch a RemoteClassLoader$ClassLoaderProxy.class file.\n"
+                            + "Usage:\n"
+                            + "    java -jar /path/to/security3430-workaround.jar <source> <target>");
             System.exit(1);
             return;
         }
         final byte[] original = Files.readAllBytes(new File(args[0]).toPath());
         final byte[] modified = innerTransform(original);
         if (modified == null) {
-            logSevereMessage("Failed to transform the specified file. Is it a RemoteClassLoader$ClassLoaderProxy.class?");
+            logSevereMessage(
+                    "Failed to transform the specified file. Is it a RemoteClassLoader$ClassLoaderProxy.class?");
             System.exit(1);
             return;
         }

--- a/src/main/java/io/jenkins/security/Security3430Workaround.java
+++ b/src/main/java/io/jenkins/security/Security3430Workaround.java
@@ -47,7 +47,7 @@ public class Security3430Workaround implements ClassFileTransformer {
 
     private static void logMessage(Level level, String message) {
         PrintStream stream = (level == Level.SEVERE) ? System.err : System.out;
-        stream.println(ZonedDateTime.now().format(formatter) + " " + level + " " + LOG_PREFIX + " " + message);
+        stream.printf("%s %s %s %s%n", ZonedDateTime.now().format(formatter), level, LOG_PREFIX, message);
     }
 
     @SuppressFBWarnings(value = "DM_EXIT", justification = "Failure to transform might result in unsafe state, so shutting down is intentional")

--- a/src/test/java/io/jenkins/security/LoggingTest.java
+++ b/src/test/java/io/jenkins/security/LoggingTest.java
@@ -1,17 +1,18 @@
 package io.jenkins.security;
 
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.instrument.IllegalClassFormatException;
+import org.junit.jupiter.api.Test;
 
 public class LoggingTest {
 
     @Test
     void logMessagePrefixedWhenSkippingTransformation() {
-        // Ensure the log message is prefixed with "SECURITY-3430 Workaround: " when skipping transformation
+        // Ensure the log message is prefixed with "INFO SECURITY-3430 Workaround: " when skipping transformation
+        PrintStream originalOut = System.out;
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
         System.setProperty(Security3430Workaround.class.getName() + ".DISABLE", "true");
@@ -19,10 +20,11 @@ public class LoggingTest {
         try {
             transformer.transform(null, "hudson/remoting/RemoteClassLoader$ClassLoaderProxy", null, null, new byte[0]);
         } catch (IllegalClassFormatException e) {
-            //ignore
+            // ignore
+        } finally {
+            assertTrue(outContent.toString().contains("INFO SECURITY-3430 Workaround: Skipping transformation of"));
+            System.clearProperty(Security3430Workaround.class.getName() + ".DISABLE");
+            System.setOut(originalOut);
         }
-        assertTrue(outContent.toString().startsWith("SECURITY-3430 Workaround: Skipping transformation of"));
-        System.clearProperty(Security3430Workaround.class.getName() + ".DISABLE");
-        System.setOut(System.out);
     }
 }

--- a/src/test/java/io/jenkins/security/LoggingTest.java
+++ b/src/test/java/io/jenkins/security/LoggingTest.java
@@ -22,7 +22,9 @@ public class LoggingTest {
         } catch (IllegalClassFormatException e) {
             // ignore
         } finally {
-            assertTrue(outContent.toString().contains("INFO SECURITY-3430 Workaround: Skipping transformation of"));
+            assertTrue(outContent
+                    .toString()
+                    .contains("INFO io.jenkins.security.Security3430Workaround Skipping transformation of "));
             System.clearProperty(Security3430Workaround.class.getName() + ".DISABLE");
             System.setOut(originalOut);
         }

--- a/src/test/java/io/jenkins/security/LoggingTest.java
+++ b/src/test/java/io/jenkins/security/LoggingTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.security;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.instrument.IllegalClassFormatException;
+
+public class LoggingTest {
+
+    @Test
+    void logMessagePrefixedWhenSkippingTransformation() {
+        // Ensure the log message is prefixed with "SECURITY-3430 Workaround: " when skipping transformation
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        System.setProperty(Security3430Workaround.class.getName() + ".DISABLE", "true");
+        Security3430Workaround transformer = new Security3430Workaround();
+        try {
+            transformer.transform(null, "hudson/remoting/RemoteClassLoader$ClassLoaderProxy", null, null, new byte[0]);
+        } catch (IllegalClassFormatException e) {
+            //ignore
+        }
+        assertTrue(outContent.toString().startsWith("SECURITY-3430 Workaround: Skipping transformation of"));
+        System.clearProperty(Security3430Workaround.class.getName() + ".DISABLE");
+        System.setOut(System.out);
+    }
+}


### PR DESCRIPTION
When using the `--logfile` argument, this workaround causes that argument to not work, and logs are instead emitted via STDOUT/STDERR (or are only available via `journalctl -u jenkins` when running via systemd).
This issue affects both Jenkins and CloudBees CI.

## Steps to reproduce

1. Download Jenkins LTS 2.452.2 from https://get.jenkins.io/war-stable/2.452.2/jenkins.war
2. Start the controller with `JENKINS_HOME=./jenkins_home java -jar ./jenkins.war --logfile=./jenkins.log` (testing done with OpenJDK Temurin-17.0.13+11)
3. Perform the initial setup and see that controller logging is working correctly in `./jenkins.log`
4. Download the SECURITY-3430 Workaround 1.0 jar https://repo.jenkins-ci.org/releases/io/jenkins/security/security3430-workaround/1.0/security3430-workaround-1.0.jar
5. Stop the controller, and start it again with the workaround: `JENKINS_HOME=./jenkins_home java -javaagent:./security3430-workaround-1.0.jar -jar ./jenkins.war --logfile=./jenkins.log`

**Expected result**: logs are still saved to ./jenkins.log
**Actual result**: Logs are emitted to STDOUT/STDERR, and ./jenkins.log is an empty file

## Testing result

I added a simple unit test to validate that the expected logging prefix is emitted.

I also tested the fix manually and the `--logfile=./jenkins.log` contains the normal controller logs, and the messages from the workaround:

```
JENKINS_HOME=./jenkins_home java -javaagent:./security3430-workaround-1.1-SNAPSHOT.jar -jar jenkins.war --logfile=./jenkins.log
2025-01-29 22:42:17.752+0000 INFO io.jenkins.security.Security3430Workaround Setting up io.jenkins.security.Security3430Workaround
Running from: /.../jenkins.war
webroot: ./jenkins_home/war
```

Then I connected an agent to the controller, and ran the testcase from https://github.com/jenkinsci-cert/SECURITY-3430?tab=readme-ov-file#testing
and inside of the ./jenkins.log, I see the normal controller logs, and I also see the `INFO io.jenkins.security.Security3430Workaround Performing transformation of ` log:

```
2025-01-29 22:42:20.907+0000 [id=38]    INFO    jenkins.InitReactorRunner$1#onAttained: Completed initialization
2025-01-29 22:42:20.927+0000 [id=27]    INFO    hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
2025-01-29 22:43:49.658+0000 INFO io.jenkins.security.Security3430Workaround Performing transformation of hudson/remoting/RemoteClassLoader$ClassLoaderProxy
```

I also noticed that when running `mvn clean verify` my local `target/security3430-workaround-1.1-SNAPSHOT.jar` contains all of the remoting jars, so it's 72 MB instead of 1 MB, though I encounter the same issue when I build the `main` branch without my changes.